### PR TITLE
Cmdinjection backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install -r requirements.txt
 
 RUN mkdir -p static
 RUN mv app.cfg test.cfg
+RUN apk add binutils libc-dev
 
 CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]
 EXPOSE 5000

--- a/backend/app.py
+++ b/backend/app.py
@@ -219,6 +219,34 @@ def get_single_video(video_id):
 
     return jsonify({'error': 'invalid method'})
 
+@app.route('/api/v1/cmdinjection', methods=['POST'])
+def cmdinjection():
+    """
+    Description: Command injection endpoint to demonstrate command injection vulnerability.
+    The frontend will have "ping this IP address!" as a input form, and attacker can 
+    perform command injection through "8.8.8.8; whoami" .
+
+    POST Param:
+        - (str) cmd: Command to be executed. 
+    """
+    #TODO: Check auth header
+
+    # Error checking for POST request 
+    request_data = request.get_json()
+    if request_data is None:
+        return jsonify({'error': 'Need cmd parameter in POST'})
+    if request_data.get('cmd', None) is None:
+        return jsonify({'error': 'cmd parameter cannot be null'})
+
+    # Command Injection happens here 
+    else:
+        userinput = request_data.get('cmd')
+        payload = 'ping -c 2 ' + userinput 
+        stream = os.popen(payload)
+        output = stream.read()
+
+        return jsonify({'result': output})
+
 
 init_db()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,3 @@ flask_sqlalchemy
 gunicorn
 pymysql
 flask_cors
-hashlib

--- a/docs/Activity7_Answers.md
+++ b/docs/Activity7_Answers.md
@@ -1,0 +1,24 @@
+# Activity 7
+
+### 1. How would you fix your code so that this issue is no longer present?
+
+The vulnerable code which causes the command injection is posted down below.
+
+**Backend - app.py @app.route('/api/v1/cmdinjection', methods=['POST'])**
+```
+  userinput = request_data.get('cmd')
+  payload = 'ping -c 2 ' + userinput 
+  stream = os.popen(payload)
+```
+
+As we can see from the code, the backend code is not sanitizing any user input. The code will simply get the parameter `cmd` from the user, and append it at the end of the payload. 
+
+To fix the code, the following practices is highly recommended. 
+
+* **Implement API:** Instead of directly calling os execution command, having a related API or a library is recommended. This in case, it was a API, but the API itself was directly calling the os execution command. 
+
+* **Sanitize user input for escape values:** Depending on the os, command injection often occurs with special characters such as `;`, `&&`, `||`, `&`, `|`, `<`, `>`, and more. Thus if the server-side programming language has a function to sanitize those special characters, it is recommended to implement them. 
+
+Such examples would be `escapeshellarg()` or `escapeshellcmd()` in PHP. 
+
+If not, creating and implementing such function would be an alternative idea.

--- a/tests/test_cmdinjection.py
+++ b/tests/test_cmdinjection.py
@@ -1,0 +1,20 @@
+import requests 
+import pytest
+
+def test_cmdinjection(url, cmd):
+    data = {'cmd': cmd}
+    #print("[DEBUG] Sending: ", data)
+    r = requests.post(url=url, json=data)
+
+    assert "Linux" in r.text
+    assert 200 == r.status_code
+
+    #print(r.text)
+
+def main():
+    url = "http://127.0.0.1:5000/api/v1/cmdinjection"
+
+    test_cmdinjection(url, '8.8.8.8; cat /etc/os-release')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added command injection api endpoint. Added docs and tests for Activity 7. 
This PR resolves #97 . This PR resolves #101. 
However, I am not sure if this is the correct way to fix #97 and #101. 

This PR partially resolves #67 - Commend Injection. However, we still need a frontend portion to send the request to the backend API.

Note: Take a close look at `/backend/Dockerfile` and `/backend/requirements.txt` changes. 